### PR TITLE
bug fix in MultilineTextFieldWidget.java

### DIFF
--- a/src/main/java/arm32x/minecraft/commandblockide/client/gui/MultilineTextFieldWidget.java
+++ b/src/main/java/arm32x/minecraft/commandblockide/client/gui/MultilineTextFieldWidget.java
@@ -168,7 +168,7 @@ public class MultilineTextFieldWidget extends TextFieldWidget {
 			charIndex++;
 		}
 
-		setCursor(charIndex, false);
+		setCursor(charIndex, Screen.hasShiftDown());
     }
 
     @Override


### PR DESCRIPTION
Fixes a bug where text would not be selected even if you clicked the mouse while holding down the Shift key.